### PR TITLE
Fix: DI-Container Redundant Repos Registration With UnitOfWork Existing - Creation of new instances of the StandardRepo

### DIFF
--- a/Investly.DAL/Repos/UnitOfWork.cs
+++ b/Investly.DAL/Repos/UnitOfWork.cs
@@ -19,8 +19,6 @@ namespace Investly.DAL.Repos
         private IInvestorContactRequestRepo _InvestorContactRequestRepo;
         private ICategoryRepo _CategoryRepo;
         private IStandardRepo _StandardRepo;
-
-
         private IGovernmentRepo _GovernmentRepo;
         private ICityRepo _CityRepo;
         private INotificationRepo _NotificationRepo;
@@ -34,15 +32,13 @@ namespace Investly.DAL.Repos
         public IGovernmentRepo GovernmentRepo => _GovernmentRepo ??= new GovermentRepo(_db);
         public ICityRepo CityRepo => _CityRepo ??= new CityRepo(_db);
         public IFounderRepo FounderRepo => _FounderRepo ??= new FounderRepo(_db);
-
         public IBusinessRepo BusinessRepo => _BusinessRepo ??= new BusinessRepo(_db);
         public INotificationRepo NotificationRepo => _NotificationRepo ??= new NotificationRepo(_db);  
         public IFeedbackRepo FeedbackRepo => _FeedbackRepo ??= new FeedbackRepo(_db);
-
         public IBusinessStandardAnswerRepo BusinessStandardAnswerRepo=>_BusinessAnswerRepo ??= new BusinessStandardAnswerRepo(_db);
         public IInvestorContactRequestRepo InvestorContactRequestRepo => _InvestorContactRequestRepo ??= new InvestorContactRequestRepo(_db);
         public ICategoryRepo CategoryRepo=>_CategoryRepo??=new CategroyRepo(_db);
-        public IStandardRepo StandardRepo=>_StandardRepo??new StandardRepo(_db);
+        public IStandardRepo StandardRepo=>_StandardRepo??=new StandardRepo(_db);
         public IAiBusinessEvaluationRepo AiBusinessEvaluationRepo => _AiBusinessEvaluationRepo ??= new AiBusinessEvaluationRepo(_db);
         public ICategoryStandardRepo CategoryStandardRepo => _CategoryStandardRepo ??= new CategoryStandardRepo(_db);
 

--- a/Investly.PL/Program.cs
+++ b/Investly.PL/Program.cs
@@ -93,10 +93,7 @@ namespace Investly.PL
 
             #region Unit of work  registeration
             builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
-            builder.Services.AddScoped<IBusinessRepo, BusinessRepo>();
-            builder.Services.AddScoped<IFeedbackRepo, FeedbackRepo>();
-            builder.Services.AddScoped<IAnalysisRepo, AnalysisRepo>();
-            builder.Services.AddScoped<ICategoryRepo,CategroyRepo>();
+
 
             #endregion
 
@@ -106,7 +103,6 @@ namespace Investly.PL
             builder.Services.AddScoped<IBusinessService, BusinessService>();
             builder.Services.AddScoped<IGovernementService,GovernmentService>();
             builder.Services.AddScoped<IFounderService, FounderService>();
-
             builder.Services.AddScoped<IGovernementService,GovernmentService>();
             builder.Services.AddScoped<INotficationService,NotificationService>();
             builder.Services.AddScoped<IInvestorContactRequestService, InvestorContactRequestService>();
@@ -151,7 +147,7 @@ namespace Investly.PL
             app.UseStaticFiles(new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(
-        Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/uploads")),
+                Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/uploads")),
                 RequestPath = "/uploads",
                 OnPrepareResponse = ctx =>
                 {


### PR DESCRIPTION
I found and removed the registered repos from UnitOfWork registration region because,

By registering repositories separately in DI Container and creating them in UnitOfWork, we'll have:
1- Two different instances of each repository.
2.- Different DbContext instances potentially.
3-  Repositories won't share the same context.

ِAlso added the missing "=" operator in UnitOfWork pattern with StandardRepo which was causing the creation of a new instance of the repo each try of access and returning it rather than assigning it to the reference.